### PR TITLE
Solve Jump scrolling bug

### DIFF
--- a/SchoolDisplay/SchoolDisplay/MainForm.cs
+++ b/SchoolDisplay/SchoolDisplay/MainForm.cs
@@ -181,7 +181,7 @@ namespace SchoolDisplay
 
         private void ResetAndStartScrollTimer()
         {
-            scrollTop = 150;
+            scrollTop = 0;
             scrollTimer.Start();
         }
 
@@ -289,7 +289,8 @@ namespace SchoolDisplay
             else
             {
                 // jump up
-                pdfRenderer.PerformScroll(ScrollAction.Home, Orientation.Vertical);
+                scrollTop = 0;
+                pdfRenderer.SetDisplayRectLocation(new Point(1, scrollTop));
                 ResetAndStartScrollTimer();
             }
         }
@@ -305,8 +306,7 @@ namespace SchoolDisplay
 
             // Jump one unit
             scrollTop -= 1;
-            var oneBelow = new PdfRectangle(0, new Rectangle(new Point(1, scrollTop), new Size(1, pdfRenderer.Height)));
-            pdfRenderer.ScrollIntoView(oneBelow);
+            pdfRenderer.SetDisplayRectLocation(new Point(1, scrollTop));
 
             // Check if end of document is reached
             var currentPos = pdfRenderer.DisplayRectangle.Top;


### PR DESCRIPTION
Solves #1 by using `pdfRenderer.SetDisplayRectLocation` method inherited from `CustomScrollControl` instead of `ScrollIntoView`.

This also increases our scrolling resolution and reduces lag.

**TODO:**
- adjust scrolling units in App.config
- do some general code cleanup - e.g. use `scrollTop` and `SetDisplayRectLocation` only in one central method

@JKamue Can you please review this?