### PR TITLE
Handle network fails correctly

### DIFF
--- a/SchoolDisplay/SchoolDisplay/Data/Pdf/CyclicPdfService.cs
+++ b/SchoolDisplay/SchoolDisplay/Data/Pdf/CyclicPdfService.cs
@@ -33,6 +33,7 @@ namespace SchoolDisplay.Data.Pdf
         /// If the last file changed in the meantime, allow it to be returned again.
         /// </summary>
         /// <exception cref="FileNotFoundException">If no files are available.</exception>
+        /// <exception cref="DirectoryNotFoundException">If the PDF directory is missing or could not be read (e. g. due to network issues).</exception>
         /// <exception cref="PdfAccessException">If something went wrong while opening a file.</exception>
         public IPdfDocument GetNextDocument()
         {
@@ -49,9 +50,17 @@ namespace SchoolDisplay.Data.Pdf
         }
 
         /// <exception cref="FileNotFoundException">If no files are available.</exception>
+        /// <exception cref="DirectoryNotFoundException">If the PDF directory is missing or could not be read (e. g. due to network issues).</exception>"
         private string GetNextFileName(bool includeCurrentFile = false)
         {
             IEnumerable<string> availableFiles = repository.ListAllFiles();
+
+            if (availableFiles == null)
+            {
+                // connection lost or 
+                currentFile = null;
+                throw new DirectoryNotFoundException("Could not read directory.");
+            }
 
             if (!availableFiles.Any())
             {

--- a/SchoolDisplay/SchoolDisplay/Data/Pdf/PdfRepository.cs
+++ b/SchoolDisplay/SchoolDisplay/Data/Pdf/PdfRepository.cs
@@ -32,13 +32,27 @@ namespace SchoolDisplay.Data.Pdf
         }
 
         /// <summary>
-        /// Get a IEnumerable of all available PDF files.
+        /// Get an IEnumerable of all available PDF files.
         /// </summary>
-        /// <returns>A string list of PDF file names.</returns>
+        /// <returns>A string list of PDF file names. Null if there were connection or directory issues.</returns>
         public IEnumerable<string> ListAllFiles()
         {
-            // hide implementation details by only returning the filename, not the path.
-            return Directory.EnumerateFiles(directoryPath, "*.pdf").Select(file => Path.GetFileName(file));
+            try
+            {
+                // hide implementation details by only returning the filename, not the path.
+                return Directory.EnumerateFiles(directoryPath, "*.pdf").Select(file => Path.GetFileName(file));
+            }
+            catch (Exception ex)
+            {
+                if (ex is IOException || ex is DirectoryNotFoundException)
+                {
+                    // we probably lost connection to our network share (or somebody deleted the directory...)
+                    return null;
+                }
+
+                throw;
+            }
+            
         }
 
         /// <summary>

--- a/SchoolDisplay/SchoolDisplay/MainForm.cs
+++ b/SchoolDisplay/SchoolDisplay/MainForm.cs
@@ -114,6 +114,14 @@ namespace SchoolDisplay
                 StartRetryTimer(settings.EmptyPollingDelay);
                 return;
             }
+            catch (DirectoryNotFoundException)
+            {
+                // error reading directory
+                ShowError(Properties.Resources.DirectoryReadError);
+
+                StartRetryTimer(settings.EmptyPollingDelay);
+                return;
+            }
             catch (PdfAccessException e)
             {
                 // something else went wrong when opening an existing PDF file.

--- a/SchoolDisplay/SchoolDisplay/Properties/Resources.Designer.cs
+++ b/SchoolDisplay/SchoolDisplay/Properties/Resources.Designer.cs
@@ -91,6 +91,15 @@ namespace SchoolDisplay.Properties {
         }
         
         /// <summary>
+        ///   Sucht eine lokalisierte Zeichenfolge, die Error reading directory. ähnelt.
+        /// </summary>
+        internal static string DirectoryReadError {
+            get {
+                return ResourceManager.GetString("DirectoryReadError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Sucht eine lokalisierte Zeichenfolge, die [Configuration Error]
         ///PDF file path is invalid. ähnelt.
         /// </summary>

--- a/SchoolDisplay/SchoolDisplay/Properties/Resources.de.resx
+++ b/SchoolDisplay/SchoolDisplay/Properties/Resources.de.resx
@@ -129,6 +129,10 @@ Konnte Konfigurationsdatei nicht laden. Bitte stellen Sie sicher, dass die Konfi
     <value>[Konfigurationsfehler]
 Konfigurationsparameter "{0}" ist nicht vorhanden.</value>
   </data>
+  <data name="DirectoryReadError" xml:space="preserve">
+    <value>Fehler beim Lesen des Verzeichnisses.</value>
+    <comment>This error will be displayed when the PDF directory could not be read.</comment>
+  </data>
   <data name="InvalidPathError" xml:space="preserve">
     <value>[Konfigurationsfehler]
 PDF-Dateipfad ist fehlerhaft.</value>

--- a/SchoolDisplay/SchoolDisplay/Properties/Resources.resx
+++ b/SchoolDisplay/SchoolDisplay/Properties/Resources.resx
@@ -129,6 +129,10 @@ Could not load configuration file. Please make sure that the configuration (.con
     <value>[Configuration Error]
 Configuration key "{0}" is missing.</value>
   </data>
+  <data name="DirectoryReadError" xml:space="preserve">
+    <value>Error reading directory.</value>
+    <comment>This error will be displayed when the PDF directory could not be read.</comment>
+  </data>
   <data name="InvalidPathError" xml:space="preserve">
     <value>[Configuration Error]
 PDF file path is invalid.</value>


### PR DESCRIPTION
- If the PDF directory is not reachable or does not exist, an approriate error message is shown. No more crashing.
- Reset FileSystemWatcher persiodically to keep the connection even after a network failure (see code comment)